### PR TITLE
Allow webpack-bundle-analyzer options to be passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,35 @@ concatenateModules: *boolean* (defaults: false)
 
 Set `concatenateModules` to `true` if you want to webpack to find segments of the module graph which can be safely concatenated into a single module
 
+### Customizing
+You can also pass other [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) options in the options array. For example, to use this in Docker environments, you can set the `analyzerHost` to `0.0.0.0`.
+
+```javascript
+// razzle.config.js
+
+module.exports = {
+  plugins: [
+    {
+      name: 'bundle-analyzer',
+      options: {
+        analyzerHost: '0.0.0.0'
+      }
+    }
+  ]
+};
+```
+
+See the full list of possible options [here](https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin)
+
 ## Run Bundle Analyzer
 
-Craete a new **script** in *package.json* 
+Craete a new **script** in *package.json*
 
 ```json
 "analyze": "BUNDLE_ANALYZE=true razzle build",
 ```
 
 and start by run this command in terminal
-```sh 
+```sh
 yarn analyze
-``` 
+```

--- a/index.js
+++ b/index.js
@@ -5,15 +5,20 @@ const defaultOptions = {
 function modify(baseConfig, { target, dev }, webpack, userOptions = {}) {
 	const options = Object.assign({}, defaultOptions, userOptions);
 	const config = Object.assign({}, baseConfig);
-	
+
 	if (process.env.BUNDLE_ANALYZE === "true" && target === "web") {
-		config.optimization.concatenateModules = options.concatenateModules
+		const {
+			concatenateModules,
+			...bundleAnalyzerOptions = {}
+		} = options
+
+		config.optimization.concatenateModules = concatenateModules
 		config.plugins.push(
-			new (require("webpack-bundle-analyzer")).BundleAnalyzerPlugin()
+			new (require("webpack-bundle-analyzer")).BundleAnalyzerPlugin(bundleAnalyzerOptions)
 		)
 	}
 
- return config;
+	return config;
 }
 
 module.exports = modify;

--- a/package.json
+++ b/package.json
@@ -11,19 +11,19 @@
     "url": "git+https://github.com/nimacsoft/razzle-plugin-bundle-analyzer.git"
   },
   "keywords": [
-		"razzle",
-		"babel",
-		"plugin",
-		"webpack-bundle-analyzer"
+    "razzle",
+    "babel",
+    "plugin",
+    "webpack-bundle-analyzer"
   ],
   "author": "Nima Arefi <nimaarefi@outlook.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/nimacsoft/razzle-plugin-bundle-analyzer/issues"
   },
-	"homepage": "https://github.com/nimacsoft/razzle-plugin-bundle-analyzer#readme",
-	"dependencies": {
-		"webpack": "~4.0.0",
-		"webpack-bundle-analyzer": ">=3.3.2"
-	}
+  "homepage": "https://github.com/nimacsoft/razzle-plugin-bundle-analyzer#readme",
+  "dependencies": {
+    "webpack": "~4.0.0",
+    "webpack-bundle-analyzer": ">=3.6.0"
+  }
 }


### PR DESCRIPTION
**Description** - This allows all options from `webpack-bundle-analyzer` to be passed to the plugin